### PR TITLE
Do not use the command attribute on a bash resource, use the 'code' a…

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -31,7 +31,6 @@ bash "install_geos_#{geos_version}" do
     ./configure && make && make install && \
     ldconfig
   EOH
-  command ""
   creates "/usr/local/bin/geos-config"
   action :run
 end


### PR DESCRIPTION
Chef::Exceptions::Script
------------------------
Do not use the command attribute on a bash resource, use the 'code' attribute instead.

Cookbook Trace:
---------------
  /home/ross/chef-solo/local-mode-cache/cache/cookbooks/geos/recipes/default.rb:34:in `block in from_file'
  /home/ross/chef-solo/local-mode-cache/cache/cookbooks/geos/recipes/default.rb:22:in `from_file'
  /home/ross/chef-solo/local-mode-cache/cache/cookbooks/Main/recipes/_geodb.rb:6:in `from_file'

Relevant File Content:
----------------------
/home/ross/chef-solo/local-mode-cache/cache/cookbooks/geos/recipes/default.rb:

 27:      bunzip2 -f #{tarball_bz2} && \
 28:      cd #{untar_dir} && \
 29:      tar xvf /tmp/#{tarball} && \
 30:      cd geos-#{geos_version} && \
 31:      ./configure && make && make install && \
 32:      ldconfig
 33:    EOH
 34>>   command ""
 35:    creates untar_dir + "/geos-#{geos_version}"
 36:    action :run
 37:  end